### PR TITLE
Use CFLAGS passed to the configure script

### DIFF
--- a/rebar.config.in
+++ b/rebar.config.in
@@ -1,6 +1,6 @@
 {erl_opts, [debug_info]}.
 
-{port_env, [{"CFLAGS", "-g -O2 -Wall"},
+{port_env, [{"CFLAGS", "-g -O2 -Wall @CFLAGS@"},
 	    {"LDFLAGS", "$ERL_LDFLAGS @LIBICONV@"}]}.
 
 {port_specs, [{"priv/lib/iconv.so", ["c_src/iconv.c"]}]}.


### PR DESCRIPTION
This is also useful to support per-package staging directory within
buildroot.

Signed-off-by: Fabio Porcedda <fabio.porcedda@gmail.com>