### PR TITLE
rebar.config,rebar.config.in: Fix LDFLAGS during build

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,7 +1,7 @@
 {erl_opts, [debug_info]}.
 
 {port_env, [{"CFLAGS", "-g -O2 -Wall -g -O2 -Wall"},
-	    {"LDFLAGS", "$ERL_LDFLAGS "}]}.
+	    {"LDFLAGS", "$LDFLAGS $ERL_LDFLAGS "}]}.
 
 {port_specs, [{"priv/lib/iconv.so", ["c_src/iconv.c"]}]}.
 

--- a/rebar.config.in
+++ b/rebar.config.in
@@ -1,7 +1,7 @@
 {erl_opts, [debug_info]}.
 
 {port_env, [{"CFLAGS", "-g -O2 -Wall @CFLAGS@"},
-	    {"LDFLAGS", "$ERL_LDFLAGS @LIBICONV@"}]}.
+	    {"LDFLAGS", "$LDFLAGS $ERL_LDFLAGS @LIBICONV@"}]}.
 
 {port_specs, [{"priv/lib/iconv.so", ["c_src/iconv.c"]}]}.
 


### PR DESCRIPTION
There happens to be linking issue if LDFLAGS are not
properly set in build. This fixes the linking error
during compilation.

Signed-off-by: Sujith H Sujith_Haridasan@mentor.com
Signed-off-by: Sujith H sujith.h@gmail.com
